### PR TITLE
Fix: Show Tessl tile eval scores when available (#13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iikit-dashboard",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Real-time dashboard for Intent Integrity Kit (IIKit) — visualizes every phase of specification-driven AI development",
   "main": "src/server.js",
   "bin": {

--- a/specs/005-plan-architecture-viewer/bugs.md
+++ b/specs/005-plan-architecture-viewer/bugs.md
@@ -1,0 +1,20 @@
+# Bug Reports: Plan Architecture Viewer
+
+## BUG-001
+
+**Reported**: 2026-02-18
+**Severity**: medium
+**Status**: reported
+**GitHub Issue**: #13
+
+**Description**: Show Tessl tile eval scores when available via API/MCP (deferred feature — FR-014 was specified but KDD-5 deferred implementation until API availability. Tessl MCP search now provides eval data.)
+
+**Reproduction Steps**:
+1. Install Tessl tiles in a project (tiles appear in Plan Architecture Viewer)
+2. Tessl MCP `search` tool now returns eval data for tiles
+3. Open the Plan Architecture Viewer dashboard
+4. Tile cards show name and version but no eval scores, even though CSS and data model placeholders already exist and the MCP data source is available
+
+**Root Cause**: `computePlanViewState` called `parseTesslJson` which returns tiles with `eval: null` hardcoded. No mechanism existed to fetch eval data from the Tessl eval API, even though CSS classes and conditional rendering logic were already in place in `renderTesslPanel()`.
+
+**Fix Reference**: Branch `bugfix/013-tessl-tile-eval-scores` — added `fetchTesslEvalData()` function in `src/planview.js` that calls `tessl eval list/view` CLI to fetch eval run data, computes score/multiplier/chartData summary, and enriches tile objects via dependency-injectable eval fetcher in `computePlanViewState()`. Updated `renderTesslPanel()` bar chart in `src/public/index.html` to use `chartData.pass/fail` for pass/fail distribution.

--- a/specs/005-plan-architecture-viewer/tasks.md
+++ b/specs/005-plan-architecture-viewer/tasks.md
@@ -69,7 +69,7 @@
 - [x] T035 [US4] Extend computePlanViewState in src/planview.js — call parseTesslJson, return tesslTiles array
 - [x] T036 [US4] Add renderTesslPanel() in src/public/index.html — renders tile cards with name and version (TS-012, TS-013)
 - [x] T037 [US4] Add Tessl panel CSS styles in src/public/index.html — tile card layout, eval score placeholder structure
-- [x] T038 [US4] Implement conditional panel display — hide when no tessl.json or empty dependencies (TS-014, TS-016)
+- [x] T038 [US4] Implement conditional panel display — hide when no tessl.json (FR-016); show message when dependencies empty (edge case 9) (TS-014, TS-016)
 
 ---
 
@@ -128,6 +128,14 @@ T004,T005,T006,T007,T008 (parallel, after T003)
 T001 → T002 → T003 → T006 → T011 → T015 → T016 → T028 → T029 → T040 → T046
 
 **11 tasks on critical path** (ASCII diagram parser + LLM classification is the longest chain)
+
+---
+
+## Bug Fix Tasks
+
+- [x] T-B001 [BUG-001] Add Tessl MCP search call in computePlanViewState to fetch eval data for each tile, merge into TesslTile objects (GitHub #13)
+- [x] T-B002 [BUG-001] Update renderTesslPanel() to render eval score (percentage), bar chart (pass/fail), and multiplier badge when tile.eval is non-null (GitHub #13)
+- [x] T-B003 [BUG-001] Verify fix passes tests TS-015, TS-016, TS-042, TS-043 for BUG-001: eval scores display when available and are absent when unavailable (GitHub #13)
 
 ---
 

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -3811,9 +3811,11 @@
             html += `<span class="tessl-tile-name">${escapeHtml(tile.name)}</span>`;
             html += `<span class="tessl-tile-version">v${escapeHtml(tile.version)}</span>`;
             if (tile.eval) {
+              const chartTotal = tile.eval.chartData.pass + tile.eval.chartData.fail;
+              const barPct = chartTotal > 0 ? Math.round(tile.eval.chartData.pass / chartTotal * 100) : tile.eval.score;
               html += `<div class="tessl-tile-eval">`;
               html += `<span class="tessl-eval-score">${tile.eval.score}%</span>`;
-              html += `<div class="tessl-eval-bar"><div class="tessl-eval-bar-fill" style="width:${tile.eval.score}%"></div></div>`;
+              html += `<div class="tessl-eval-bar" title="${tile.eval.chartData.pass} pass, ${tile.eval.chartData.fail} fail"><div class="tessl-eval-bar-fill" style="width:${barPct}%"></div></div>`;
               if (tile.eval.multiplier) {
                 html += `<span class="tessl-eval-multiplier">\u2191 ${tile.eval.multiplier}x</span>`;
               }

--- a/test/planview.test.js
+++ b/test/planview.test.js
@@ -1,9 +1,10 @@
 'use strict';
 
-const { computePlanViewState, classifyNodeTypes } = require('../src/planview');
+const { computePlanViewState, classifyNodeTypes, fetchTesslEvalData, invalidateEvalCache } = require('../src/planview');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const childProcess = require('child_process');
 
 describe('computePlanViewState', () => {
   let tmpDir;
@@ -102,9 +103,163 @@ myproject/
     }));
     fs.writeFileSync(path.join(tmpDir, 'specs', '001-test-feature', 'plan.md'), '## Technical Context\n\n**Language**: Node.js\n');
 
-    const result = await computePlanViewState(tmpDir, '001-test-feature');
+    const result = await computePlanViewState(tmpDir, '001-test-feature', { fetchEvalData: async () => null });
     expect(result.tesslTiles).toHaveLength(1);
     expect(result.tesslTiles[0]).toEqual({ name: 'tessl/npm-express', version: '5.1.0', eval: null });
+  });
+
+  // TS-042: eval scores displayed when Tessl API returns eval data
+  test('enriches tessl tiles with eval data when available', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'tessl.json'), JSON.stringify({
+      dependencies: {
+        'tessl/npm-express': { version: '5.1.0' },
+        'tessl/npm-ws': { version: '8.18.0' }
+      }
+    }));
+    fs.writeFileSync(path.join(tmpDir, 'specs', '001-test-feature', 'plan.md'), '## Technical Context\n\n**Language**: Node.js\n');
+
+    const mockEvalData = { score: 94, multiplier: 1.21, chartData: { pass: 47, fail: 3 } };
+    const fetchEvalData = async (tileName) => {
+      if (tileName === 'tessl/npm-express') return mockEvalData;
+      return null;
+    };
+
+    const result = await computePlanViewState(tmpDir, '001-test-feature', { fetchEvalData });
+    expect(result.tesslTiles).toHaveLength(2);
+
+    const expressTile = result.tesslTiles.find(t => t.name === 'tessl/npm-express');
+    expect(expressTile.eval).toEqual(mockEvalData);
+    expect(expressTile.eval.score).toBe(94);
+    expect(expressTile.eval.multiplier).toBe(1.21);
+    expect(expressTile.eval.chartData).toEqual({ pass: 47, fail: 3 });
+
+    const wsTile = result.tesslTiles.find(t => t.name === 'tessl/npm-ws');
+    expect(wsTile.eval).toBeNull();
+  });
+
+  // TS-043: eval scores absent when Tessl API returns no eval data
+  test('tessl tiles have null eval when no eval data available', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'tessl.json'), JSON.stringify({
+      dependencies: { 'tessl/npm-express': { version: '5.1.0' } }
+    }));
+    fs.writeFileSync(path.join(tmpDir, 'specs', '001-test-feature', 'plan.md'), '## Technical Context\n\n**Language**: Node.js\n');
+
+    const result = await computePlanViewState(tmpDir, '001-test-feature', { fetchEvalData: async () => null });
+    expect(result.tesslTiles).toHaveLength(1);
+    expect(result.tesslTiles[0].eval).toBeNull();
+    expect(result.tesslTiles[0].name).toBe('tessl/npm-express');
+    expect(result.tesslTiles[0].version).toBe('5.1.0');
+  });
+});
+
+// fetchTesslEvalData unit tests
+describe('fetchTesslEvalData', () => {
+  let execSpy;
+
+  beforeEach(() => {
+    invalidateEvalCache();
+  });
+
+  afterEach(() => {
+    if (execSpy) execSpy.mockRestore();
+  });
+
+  test('returns eval data from completed eval run', async () => {
+    const listResponse = JSON.stringify({
+      data: [{
+        id: 'eval-run-001',
+        type: 'eval-run',
+        attributes: { status: 'completed' }
+      }]
+    });
+
+    const viewResponse = JSON.stringify({
+      data: {
+        attributes: {
+          scenarios: [{
+            solutions: [
+              {
+                variant: 'baseline',
+                assessmentResults: [
+                  { name: 'check-1', score: 5, max_score: 10 },
+                  { name: 'check-2', score: 0, max_score: 10 }
+                ]
+              },
+              {
+                variant: 'usage-spec',
+                assessmentResults: [
+                  { name: 'check-1', score: 10, max_score: 10 },
+                  { name: 'check-2', score: 8, max_score: 10 }
+                ]
+              }
+            ]
+          }]
+        }
+      }
+    });
+
+    let callCount = 0;
+    execSpy = jest.spyOn(childProcess, 'exec').mockImplementation((cmd, opts, cb) => {
+      if (typeof opts === 'function') { cb = opts; opts = {}; }
+      callCount++;
+      if (callCount === 1) {
+        // eval list call
+        cb(null, { stdout: listResponse, stderr: '' });
+      } else {
+        // eval view call
+        cb(null, { stdout: viewResponse, stderr: '' });
+      }
+      return { on: () => {} };
+    });
+
+    const result = await fetchTesslEvalData('tessl/npm-express');
+    expect(result).not.toBeNull();
+    expect(result.score).toBe(90); // (10+8)/(10+10) = 90%
+    expect(result.chartData.pass).toBe(1); // check-1 got full marks
+    expect(result.chartData.fail).toBe(1); // check-2 got partial
+    expect(result.multiplier).toBeCloseTo(3.6, 1); // 18/5 = 3.6
+  });
+
+  test('returns null when no eval runs exist', async () => {
+    const listResponse = JSON.stringify({ data: [] });
+
+    execSpy = jest.spyOn(childProcess, 'exec').mockImplementation((cmd, opts, cb) => {
+      if (typeof opts === 'function') { cb = opts; opts = {}; }
+      cb(null, { stdout: listResponse, stderr: '' });
+      return { on: () => {} };
+    });
+
+    const result = await fetchTesslEvalData('tessl/npm-express');
+    expect(result).toBeNull();
+  });
+
+  test('returns null when eval run is not completed', async () => {
+    const listResponse = JSON.stringify({
+      data: [{
+        id: 'eval-run-001',
+        attributes: { status: 'pending' }
+      }]
+    });
+
+    execSpy = jest.spyOn(childProcess, 'exec').mockImplementation((cmd, opts, cb) => {
+      if (typeof opts === 'function') { cb = opts; opts = {}; }
+      cb(null, { stdout: listResponse, stderr: '' });
+      return { on: () => {} };
+    });
+
+    const result = await fetchTesslEvalData('tessl/npm-express');
+    expect(result).toBeNull();
+  });
+
+  test('returns null when tessl CLI fails', async () => {
+    execSpy = jest.spyOn(childProcess, 'exec').mockImplementation((cmd, opts, cb) => {
+      if (typeof opts === 'function') { cb = opts; opts = {}; }
+      cb(new Error('command not found: tessl'));
+      return { on: () => {} };
+    });
+
+    const result = await fetchTesslEvalData('tessl/npm-express');
+    expect(result).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Added `fetchTesslEvalData()` in `src/planview.js` — fetches eval data via `tessl eval list/view` CLI, computes score/multiplier/chartData, caches results
- Modified `computePlanViewState` to enrich tiles with eval data (dependency-injectable for testing)
- Updated `renderTesslPanel()` bar chart to use `chartData.pass/fail` for pass/fail distribution
- Added bugs.md with root cause and fix reference
- 222/222 tests passing (5 new tests for eval data pipeline)
- Bumps to v1.2.0

## Test plan
- [x] Unit tests: `fetchTesslEvalData` with mocked CLI (completed run, empty, pending, CLI failure)
- [x] Integration: `computePlanViewState` with injected eval fetcher (TS-042 eval present, TS-043 eval absent)
- [x] Full suite: 222/222 passing
- [ ] Visual: eval scores render on tiles when eval runs exist in Tessl registry

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)