### PR TITLE
fix(007-testify-traceability): migrate to Gherkin .feature files (v2.0.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iikit-dashboard",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iikit-dashboard",
-      "version": "1.7.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iikit-dashboard",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "Real-time dashboard for Intent Integrity Kit (IIKit) — visualizes every phase of specification-driven AI development",
   "main": "src/generate-dashboard.js",
   "bin": {

--- a/specs/007-testify-traceability/bugs.md
+++ b/specs/007-testify-traceability/bugs.md
@@ -1,0 +1,21 @@
+# Bug Reports: testify-traceability
+
+## BUG-001
+
+**Reported**: 2026-02-21
+**Severity**: high
+**Status**: reported
+**GitHub Issue**: #30
+
+**Description**: Dashboard parses test-specs.md markdown format but IIKit core has migrated to standard Gherkin .feature files — parser, integrity hash, pipeline detection, and file watcher all reference the old format
+
+**Reproduction Steps**:
+1. Run IIKit testify phase which now generates tests/features/*.feature files instead of tests/test-specs.md
+2. Open the dashboard for a feature with Gherkin .feature files
+3. Observe: Testify panel shows empty state because parser cannot find or parse test-specs.md
+4. Observe: Integrity seal shows "Missing" because hash computation targets old file
+5. Observe: Pipeline phase detection shows Testify as "not_started" despite .feature files existing
+
+**Root Cause**: _(empty until investigation)_
+
+**Fix Reference**: _(empty until implementation)_

--- a/specs/007-testify-traceability/context.json
+++ b/specs/007-testify-traceability/context.json
@@ -1,7 +1,7 @@
 {
   "testify": {
-    "assertion_hash": "110de136690402dc6a16bdaf83d37ee66c97670c7b03279c92538dda4a9547a1",
-    "generated_at": "2026-02-18T03:39:19Z",
+    "assertion_hash": "f2b42078554117210b42cfd9f1f30ee5978acd020435ef6f2dad35d055613868",
+    "generated_at": "2026-02-22T05:25:42Z",
     "test_specs_file": "specs/007-testify-traceability/tests/test-specs.md"
   }
 }

--- a/specs/007-testify-traceability/tasks.md
+++ b/specs/007-testify-traceability/tasks.md
@@ -140,3 +140,10 @@ Phase 9:          [T022, T023] (independent) | T024 | T025
 **Increment 2 (Phase 7-8)**: US5 + US6 = Hover interaction and real-time updates. Polish interactions for complex diagrams.
 
 **Final (Phase 9)**: Accessibility, animation, edge cases. Production-grade polish.
+
+---
+
+## Bug Fix Tasks
+
+- [ ] T-B001 [BUG-001] Implement fix for BUG-001 referencing test specs TS-033 through TS-037: migrate parseTestSpecs to Gherkin .feature format, update computeAssertionHash for Gherkin step lines, update computeTestifyState/computePipelineState/getBoardState to glob tests/features/*.feature, update file watcher glob, update test fixtures and tests (GitHub #30)
+- [ ] T-B002 [BUG-001] Verify fix passes tests TS-033 through TS-037 for BUG-001: run full test suite confirming Gherkin parsing, multi-file integrity hash, pipeline detection, multi-file aggregation, and advanced Gherkin constructs (GitHub #30)

--- a/specs/007-testify-traceability/tests/test-specs.md
+++ b/specs/007-testify-traceability/tests/test-specs.md
@@ -478,6 +478,78 @@ If requirements change, re-run /iikit-05-testify to regenerate test specs.
 
 ---
 
+## Bug Fix Tests
+
+### TS-033: parseTestSpecs parses Gherkin .feature file format
+
+**Source**: BUG-001:Gherkin parser support
+**Type**: validation
+**Priority**: P1
+
+**Given**: a Gherkin .feature file containing `@TS-001 @P1 @acceptance @FR-001 @SC-001` tags followed by `Scenario: Login with valid credentials` and Given/When/Then steps
+**When**: parseTestSpecs() parses the content
+**Then**: the result contains an entry with id "TS-001", title "Login with valid credentials", type "acceptance", priority "P1", and traceability ["FR-001", "SC-001"]
+
+**Traceability**: FR-001, BUG-001
+
+---
+
+### TS-034: computeAssertionHash extracts Gherkin step lines from multiple sorted files
+
+**Source**: BUG-001:integrity hash migration
+**Type**: validation
+**Priority**: P1
+
+**Given**: two .feature files where file "a.feature" contains `Given a user` / `When they login` / `Then they see dashboard` and file "b.feature" contains `Given an admin` / `When they login` / `Then they see admin panel`
+**When**: computeAssertionHash() is called with the concatenated content (files sorted by name)
+**Then**: the hash is computed from lines matching `^\s*(Given|When|Then|And|But) ` with leading whitespace stripped, producing a deterministic SHA256 hash
+
+**Traceability**: FR-009, FR-010, BUG-001
+
+---
+
+### TS-035: Pipeline detects Testify phase from .feature files
+
+**Source**: BUG-001:pipeline detection
+**Type**: validation
+**Priority**: P1
+
+**Given**: a feature directory containing tests/features/acceptance.feature but no tests/test-specs.md
+**When**: computePipelineState() evaluates the testify phase
+**Then**: the testify phase status is "complete" (not "not_started")
+
+**Traceability**: FR-013, BUG-001
+
+---
+
+### TS-036: computeTestifyState aggregates test specs from multiple .feature files
+
+**Source**: BUG-001:multi-file aggregation
+**Type**: validation
+**Priority**: P1
+
+**Given**: a feature directory with tests/features/acceptance.feature containing 3 test specs and tests/features/validation.feature containing 2 test specs
+**When**: computeTestifyState() is called
+**Then**: the returned testSpecs array contains all 5 test specs with correct ids, types, priorities, and traceability links
+
+**Traceability**: FR-001, FR-002, BUG-001
+
+---
+
+### TS-037: Gherkin Background and Scenario Outline parsed without breaking
+
+**Source**: BUG-001:advanced Gherkin constructs
+**Type**: validation
+**Priority**: P2
+
+**Given**: a .feature file containing Background: with shared Given steps, Scenario Outline: with Examples: table, and Rule: grouping
+**When**: parseTestSpecs() parses the content
+**Then**: the parser does not throw errors and correctly extracts tagged scenarios (Background steps are not counted as separate test specs)
+
+**Traceability**: FR-001, BUG-001
+
+---
+
 ## Summary
 
 | Source | Count | Types |
@@ -485,4 +557,5 @@ If requirements change, re-run /iikit-05-testify to regenerate test specs.
 | spec.md | 20 | acceptance |
 | plan.md | 3 | contract |
 | data-model.md | 9 | validation |
-| **Total** | **32** | |
+| BUG-001 | 5 | validation |
+| **Total** | **37** | |

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const { parseTasks, parseChecklists, parseConstitutionTDD, hasClarifications } = require('./parser');
+const { getFeatureFiles } = require('./testify');
 
 /**
  * Compute pipeline phase states for a feature by examining artifacts on disk.
@@ -17,7 +18,6 @@ function computePipelineState(projectPath, featureId) {
   const specPath = path.join(featureDir, 'spec.md');
   const planPath = path.join(featureDir, 'plan.md');
   const checklistDir = path.join(featureDir, 'checklists');
-  const testSpecsPath = path.join(featureDir, 'tests', 'test-specs.md');
   const tasksPath = path.join(featureDir, 'tasks.md');
 
   const analysisPath = path.join(featureDir, 'analysis.md');
@@ -25,7 +25,7 @@ function computePipelineState(projectPath, featureId) {
   const specExists = fs.existsSync(specPath);
   const planExists = fs.existsSync(planPath);
   const tasksExists = fs.existsSync(tasksPath);
-  const testSpecsExists = fs.existsSync(testSpecsPath);
+  const testSpecsExists = getFeatureFiles(featureDir).length > 0;
   const constitutionExists = fs.existsSync(constitutionPath);
   const premiseExists = fs.existsSync(path.join(projectPath, 'PREMISE.md'));
   const analysisExists = fs.existsSync(analysisPath);

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -5331,7 +5331,7 @@
           case 'missing':
             textEl.textContent = 'Missing';
             badge.setAttribute('aria-label', 'Test integrity: no hash data available');
-            badge.title = 'No test-specs.md or context.json found';
+            badge.title = 'No test specifications or context.json found';
             break;
         }
       }

--- a/test/fixtures/testify/context.json
+++ b/test/fixtures/testify/context.json
@@ -1,7 +1,7 @@
 {
   "testify": {
-    "assertion_hash": "3e2b91db8b93a2d5424b7b1fc5d130a6e149914a021d8ee4477b30a0c48bc04c",
+    "assertion_hash": "67513b79ac6baf7bd2d9f71fd9ecc20bd2aa3b8813d2532e4778dd275305df4e",
     "generated_at": "2026-02-17T00:00:00Z",
-    "test_specs_file": "tests/test-specs.md"
+    "test_specs_file": "tests/features/*.feature"
   }
 }

--- a/test/fixtures/testify/tests/features/acceptance.feature
+++ b/test/fixtures/testify/tests/features/acceptance.feature
@@ -1,0 +1,19 @@
+Feature: Acceptance Tests
+
+  @TS-001 @acceptance @P1 @FR-001 @SC-001
+  Scenario: Dashboard displays on load
+    Given a project with valid data
+    When the dashboard loads
+    Then all components render correctly
+
+  @TS-002 @acceptance @P2 @FR-002 @SC-002
+  Scenario: Filtering works correctly
+    Given a dashboard with items
+    When a filter is applied
+    Then only matching items are shown
+
+  @TS-003 @acceptance @P1 @FR-001 @FR-002 @SC-001
+  Scenario: Multi-requirement coverage
+    Given a feature with multiple requirements
+    When the dashboard loads
+    Then all requirements are represented

--- a/test/fixtures/testify/tests/features/contract.feature
+++ b/test/fixtures/testify/tests/features/contract.feature
@@ -1,0 +1,13 @@
+Feature: Contract Tests
+
+  @TS-004 @contract @P1 @FR-001 @FR-003
+  Scenario: API returns correct response
+    Given a valid feature
+    When GET /api/data is called
+    Then response contains expected shape
+
+  @TS-005 @contract @P1 @FR-003 @SC-002
+  Scenario: WebSocket pushes updates
+    Given a connected client
+    When data changes on disk
+    Then update message is sent

--- a/test/fixtures/testify/tests/features/validation.feature
+++ b/test/fixtures/testify/tests/features/validation.feature
@@ -1,0 +1,19 @@
+Feature: Validation Tests
+
+  @TS-006 @validation @P2 @FR-001
+  Scenario: Parser extracts IDs correctly
+    Given well-formed markdown content
+    When parser runs
+    Then all IDs are extracted
+
+  @TS-007 @validation @P2 @FR-002 @FR-005
+  Scenario: Edge derivation handles orphans
+    Given references to non-existent entities
+    When edges are derived
+    Then orphaned references are ignored
+
+  @TS-008 @validation @P2 @FR-004 @SC-003
+  Scenario: Gap computation is correct
+    Given a set of nodes and edges
+    When gaps are computed
+    Then untested requirements and unimplemented tests are identified

--- a/test/generate-dashboard.test.js
+++ b/test/generate-dashboard.test.js
@@ -85,7 +85,7 @@ describe('Compute module smoke tests', () => {
     const { computeAssertionHash, checkIntegrity } = require('../src/integrity');
     expect(typeof computeAssertionHash).toBe('function');
     expect(typeof checkIntegrity).toBe('function');
-    const hash = computeAssertionHash('**Given**: a project\n**When**: run\n**Then**:\n- result\n');
+    const hash = computeAssertionHash('    Given a project\n    When run\n    Then result\n');
     expect(typeof hash).toBe('string');
     expect(hash.length).toBe(64); // SHA-256 hex
     const result = checkIntegrity(hash, hash);

--- a/test/integrity.test.js
+++ b/test/integrity.test.js
@@ -1,13 +1,13 @@
 const { computeAssertionHash, checkIntegrity } = require('../src/integrity');
 
-// TS-017: Integrity check detects hash mismatch
+// TS-017: Integrity check detects hash mismatch (Gherkin format)
 describe('computeAssertionHash', () => {
-  test('computes SHA256 hash from Given/When/Then lines', () => {
-    const content = `### TS-001: Live task checkbox update
-
-**Given**: a feature with tasks.md containing 10 unchecked tasks
-**When**: an agent checks off a task
-**Then**: the checkbox updates within 5 seconds
+  test('computes SHA256 hash from Gherkin step lines', () => {
+    const content = `Feature: Dashboard
+  Scenario: Live task checkbox update
+    Given a feature with tasks.md containing 10 unchecked tasks
+    When an agent checks off a task
+    Then the checkbox updates within 5 seconds
 `;
     const hash = computeAssertionHash(content);
     expect(hash).toBeDefined();
@@ -16,9 +16,9 @@ describe('computeAssertionHash', () => {
   });
 
   test('same content produces same hash', () => {
-    const content = `**Given**: input A
-**When**: action B
-**Then**: result C
+    const content = `    Given input A
+    When action B
+    Then result C
 `;
     const hash1 = computeAssertionHash(content);
     const hash2 = computeAssertionHash(content);
@@ -26,13 +26,13 @@ describe('computeAssertionHash', () => {
   });
 
   test('different content produces different hash', () => {
-    const content1 = `**Given**: input A
-**When**: action B
-**Then**: result C
+    const content1 = `    Given input A
+    When action B
+    Then result C
 `;
-    const content2 = `**Given**: input A
-**When**: action B
-**Then**: result D
+    const content2 = `    Given input A
+    When action B
+    Then result D
 `;
     const hash1 = computeAssertionHash(content1);
     const hash2 = computeAssertionHash(content2);
@@ -40,17 +40,29 @@ describe('computeAssertionHash', () => {
   });
 
   test('whitespace normalization produces consistent hashes', () => {
-    const content1 = `**Given**:  input   A
-**When**:  action  B
-**Then**:  result  C
+    const content1 = `    Given  input   A
+    When  action  B
+    Then  result  C
 `;
-    const content2 = `**Given**: input A
-**When**: action B
-**Then**: result C
+    const content2 = `    Given input A
+    When action B
+    Then result C
 `;
     const hash1 = computeAssertionHash(content1);
     const hash2 = computeAssertionHash(content2);
     expect(hash1).toBe(hash2);
+  });
+
+  test('extracts And and But step keywords', () => {
+    const content = `    Given input A
+    And input B
+    When action C
+    But not action D
+    Then result E
+`;
+    const hash = computeAssertionHash(content);
+    expect(hash).toBeDefined();
+    expect(hash).toHaveLength(64);
   });
 
   test('returns null for content with no assertions', () => {

--- a/test/pipeline.test.js
+++ b/test/pipeline.test.js
@@ -213,7 +213,7 @@ describe('computePipelineState', () => {
       'spec.md': '# Spec\n## Clarifications\n### Session\n- Q: x -> A: y\n',
       'plan.md': '# Plan',
       'checklists/req.md': '- [x] CHK001 Done\n',
-      'tests/test-specs.md': '# Test Specs\n### TS-001\n',
+      'tests/features/acceptance.feature': '@TS-001 @acceptance @P1\nScenario: Test\n  Given x\n  Then y\n',
       'tasks.md': '# Tasks\n- [x] T001 Done\n- [x] T002 Done\n',
       'analysis.md': '# Analysis Report\nAll clear.\n'
     });

--- a/test/visual/helpers.js
+++ b/test/visual/helpers.js
@@ -180,69 +180,53 @@ As a user, I want my session to persist so that I don't have to log in repeatedl
 - [ ] T015 [US1] Add authentication event audit logging
 `);
 
-  fs.writeFileSync(path.join(testsDir1, 'test-specs.md'), `# Test Specifications
+  const featuresDir1 = path.join(testsDir1, 'features');
+  fs.mkdirSync(featuresDir1, { recursive: true });
 
-### TS-001: Email Login Authentication (Type: acceptance, Priority: P1)
+  fs.writeFileSync(path.join(featuresDir1, 'acceptance.feature'), `Feature: Acceptance Tests
 
-Verifies that users can log in with valid email and password credentials.
+  @TS-001 @acceptance @P1 @FR-001 @SC-001
+  Scenario: Email Login Authentication
+    Given a registered user with email "test@example.com" and valid password
+    When they submit the login form with correct credentials
+    Then they receive a 200 response with a valid session token within 3 seconds
 
-**Traceability**: FR-001, SC-001
-**Task**: T003, T004
+  @TS-003 @acceptance @P1 @FR-002 @SC-002
+  Scenario: Password Reset Flow
+    Given a registered user who has forgotten their password
+    When they request a password reset for their email
+    Then a reset email is sent within 30 seconds with a valid token
+`);
 
-**Given**: a registered user with email "test@example.com" and valid password
-**When**: they submit the login form with correct credentials
-**Then**: they receive a 200 response with a valid session token within 3 seconds
+  fs.writeFileSync(path.join(featuresDir1, 'contract.feature'), `Feature: Contract Tests
 
-### TS-002: Login Validation Errors (Type: validation, Priority: P1)
+  @TS-004 @contract @P2 @FR-003 @SC-003
+  Scenario: OAuth Google Login
+    Given a user with a valid Google account
+    When they initiate the Google OAuth flow
+    Then the system exchanges the auth code for tokens and creates a session
+`);
 
-Verifies proper error handling for invalid login attempts.
+  fs.writeFileSync(path.join(featuresDir1, 'validation.feature'), `Feature: Validation Tests
 
-**Traceability**: FR-001
-**Task**: T005
+  @TS-002 @validation @P1 @FR-001
+  Scenario: Login Validation Errors
+    Given a user with an invalid email format
+    When they submit the login form
+    Then they see a validation error "Invalid email format"
 
-**Given**: a user with an invalid email format
-**When**: they submit the login form
-**Then**: they see a validation error "Invalid email format"
-
-### TS-003: Password Reset Flow (Type: acceptance, Priority: P1)
-
-Verifies the complete password reset flow from request to completion.
-
-**Traceability**: FR-002, SC-002
-**Task**: T006, T007, T008
-
-**Given**: a registered user who has forgotten their password
-**When**: they request a password reset for their email
-**Then**: a reset email is sent within 30 seconds with a valid token
-
-### TS-004: OAuth Google Login (Type: contract, Priority: P2)
-
-Verifies Google OAuth integration follows the OAuth 2.0 specification.
-
-**Traceability**: FR-003, SC-003
-**Task**: T009, T011
-
-**Given**: a user with a valid Google account
-**When**: they initiate the Google OAuth flow
-**Then**: the system exchanges the auth code for tokens and creates a session
-
-### TS-005: Rate Limiting (Type: validation, Priority: P1)
-
-Verifies that login attempts are properly rate-limited.
-
-**Traceability**: FR-006
-**Task**: T014
-
-**Given**: an IP address that has made 5 failed login attempts in the last minute
-**When**: they attempt a 6th login
-**Then**: the request is rejected with a 429 status code
+  @TS-005 @validation @P1 @FR-006
+  Scenario: Rate Limiting
+    Given an IP address that has made 5 failed login attempts in the last minute
+    When they attempt a 6th login
+    Then the request is rejected with a 429 status code
 `);
 
   fs.writeFileSync(path.join(feature1Dir, 'context.json'), JSON.stringify({
     testify: {
       assertion_hash: 'abc123def456',
       generated_at: '2026-02-10T00:00:00Z',
-      test_specs_file: 'specs/001-auth/tests/test-specs.md'
+      test_specs_file: 'specs/001-auth/tests/features/*.feature'
     }
   }));
 

--- a/test/visual/snapshots/dashboard.dom-structure.spec.js/linux/testify-view-dom-structure.json
+++ b/test/visual/snapshots/dashboard.dom-structure.spec.js/linux/testify-view-dom-structure.json
@@ -153,17 +153,6 @@
                         "sankey-flow"
                       ],
                       "dataAttrs": {
-                        "data-chain-ids": "FR-001 TS-002",
-                        "data-from": "FR-001",
-                        "data-to": "TS-002"
-                      }
-                    },
-                    {
-                      "tag": "path",
-                      "classes": [
-                        "sankey-flow"
-                      ],
-                      "dataAttrs": {
                         "data-chain-ids": "FR-002 TS-003",
                         "data-from": "FR-002",
                         "data-to": "TS-003"
@@ -200,6 +189,17 @@
                         "data-chain-ids": "SC-003 TS-004",
                         "data-from": "SC-003",
                         "data-to": "TS-004"
+                      }
+                    },
+                    {
+                      "tag": "path",
+                      "classes": [
+                        "sankey-flow"
+                      ],
+                      "dataAttrs": {
+                        "data-chain-ids": "FR-001 TS-002",
+                        "data-from": "FR-001",
+                        "data-to": "TS-002"
                       }
                     },
                     {
@@ -788,49 +788,6 @@
                         "sankey-node"
                       ],
                       "dataAttrs": {
-                        "data-node-id": "TS-002",
-                        "data-chain": "TS-002 FR-001",
-                        "data-cross-target": "checklist",
-                        "data-cross-id": "TS-002"
-                      },
-                      "ariaAttrs": {
-                        "aria-describedby": "desc-TS-002"
-                      },
-                      "role": "button",
-                      "children": [
-                        {
-                          "tag": "title"
-                        },
-                        {
-                          "tag": "desc"
-                        },
-                        {
-                          "tag": "rect",
-                          "classes": [
-                            "sankey-node-rect"
-                          ]
-                        },
-                        {
-                          "tag": "text",
-                          "classes": [
-                            "sankey-node-label"
-                          ]
-                        },
-                        {
-                          "tag": "text",
-                          "classes": [
-                            "sankey-node-desc"
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "tag": "g",
-                      "classes": [
-                        "gap-node",
-                        "sankey-node"
-                      ],
-                      "dataAttrs": {
                         "data-node-id": "TS-003",
                         "data-chain": "TS-003 FR-002 SC-002",
                         "data-cross-target": "checklist",
@@ -881,6 +838,49 @@
                       },
                       "ariaAttrs": {
                         "aria-describedby": "desc-TS-004"
+                      },
+                      "role": "button",
+                      "children": [
+                        {
+                          "tag": "title"
+                        },
+                        {
+                          "tag": "desc"
+                        },
+                        {
+                          "tag": "rect",
+                          "classes": [
+                            "sankey-node-rect"
+                          ]
+                        },
+                        {
+                          "tag": "text",
+                          "classes": [
+                            "sankey-node-label"
+                          ]
+                        },
+                        {
+                          "tag": "text",
+                          "classes": [
+                            "sankey-node-desc"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "tag": "g",
+                      "classes": [
+                        "gap-node",
+                        "sankey-node"
+                      ],
+                      "dataAttrs": {
+                        "data-node-id": "TS-002",
+                        "data-chain": "TS-002 FR-001",
+                        "data-cross-target": "checklist",
+                        "data-cross-id": "TS-002"
+                      },
+                      "ariaAttrs": {
+                        "aria-describedby": "desc-TS-002"
                       },
                       "role": "button",
                       "children": [


### PR DESCRIPTION
## Summary
- Migrate from `test-specs.md` markdown format to standard Gherkin `.feature` files
- Rewrite `parseTestSpecs()` to parse `@tag` annotations and `Scenario:` lines
- Rewrite `computeAssertionHash()` for Gherkin step keywords (Given/When/Then/And/But)
- Add `getFeatureFiles()` shared helper for `tests/features/*.feature` globbing
- Update testify, pipeline, and dashboard generator to use `.feature` files
- Bump to v2.0.0 (breaking parser/integrity API contract change)

## Test plan
- [x] `npx jest` — all 331 unit tests pass (13 suites)
- [x] `node src/generate-dashboard.js .` — produces dashboard.html without errors
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)